### PR TITLE
POSフロントを開発しました

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "cmdk": "1.0.4",
         "date-fns": "4.1.0",
         "input-otp": "1.4.1",
+        "jsqr": "^1.4.0",
         "lucide-react": "^0.536.0",
         "next": "^14.2.15",
         "next-themes": "^0.4.6",
@@ -5980,6 +5981,12 @@
       "bin": {
         "json5": "lib/cli.js"
       }
+    },
+    "node_modules/jsqr": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsqr/-/jsqr-1.4.0.tgz",
+      "integrity": "sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==",
+      "license": "Apache-2.0"
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",
     "input-otp": "1.4.1",
+    "jsqr": "^1.4.0",
     "lucide-react": "^0.536.0",
     "next": "^14.2.15",
     "next-themes": "^0.4.6",

--- a/src/app/pos/page.tsx
+++ b/src/app/pos/page.tsx
@@ -1,0 +1,344 @@
+"use client"
+
+import { useState, useMemo, useEffect } from "react"
+import dynamic from "next/dynamic"
+import { Camera, X, Check } from "lucide-react"
+import { motion, AnimatePresence } from "framer-motion"
+
+// QrScanner を default / named どちらでも読み込む（SSR無効）
+const QrScanner = dynamic(async () => {
+  const m = await import("@/components/qr-scanner")
+  return (m as any).default ?? (m as any).QrScanner
+}, {
+  ssr: false,
+  loading: () => (
+    <div className="text-center text-sm text-gray-500 py-8">カメラを準備中...</div>
+  ),
+})
+
+// ▼ これをpage.tsx内の上のほうに追加（コンポーネントの外でも中でもOK）
+function HideGlobalFooter() {
+  useEffect(() => {
+    // ありそうなセレクタを複数カバー（お使いの実装に合わせて適宜追加OK）
+    const selectors = [
+      '#app-footer',            // 推奨: フッターにidがある場合
+      '[data-bottom-nav]',      // data属性版
+      '[data-role="bottom-nav"]',
+      '.bottom-nav',            // クラス名が bottom-nav の場合
+      '.mobile-tabbar',         // タブバー系
+      'footer',                 // <footer> タグ（他のfooterがなければこれでOK）
+    ]
+    const els: HTMLElement[] = []
+    selectors.forEach(sel =>
+      els.push(...Array.from(document.querySelectorAll<HTMLElement>(sel)))
+    )
+
+    // 退避 & 非表示
+    const prev = new Map<HTMLElement, string>()
+    els.forEach(el => { prev.set(el, el.style.display); el.style.display = 'none' })
+
+    // ページ遷移で戻す
+    return () => els.forEach(el => { el.style.display = prev.get(el) ?? '' })
+  }, [])
+  return null
+}
+// ▲ これをpage.tsx内の上のほうに追加（コンポーネントの外でも中でもOK）
+
+type ExecuteResponse = {
+  transaction_id: number
+  amount_paid: number
+  tanabota_total: number
+  executions: Array<{
+    rule_id: number
+    action_id: number
+    action_type: string
+    tanabota_amount: number
+  }>
+}
+
+const joinUrl = (base: string, path: string) => {
+  const b = base.replace(/\/+$/, "")
+  const p = path.replace(/^\/+/, "")
+  return `${b}/${p}`
+}
+
+export default function POSApp() {
+  // ---- すべて初期化状態で開始（退避なし）----
+  const [isScanning, setIsScanning] = useState(false)
+  const [scannedUserId, setScannedUserId] = useState<string>("")
+  const [amount, setAmount] = useState<string>("")
+  const [isProcessing, setIsProcessing] = useState(false)
+  const [paymentComplete, setPaymentComplete] = useState(false)
+
+  // 画面には出さないデバッグ用
+  const [lastTriedUrl, setLastTriedUrl] = useState<string>("")
+  const [error, setError] = useState<string>("")
+
+  const baseUrl = useMemo(() => process.env.NEXT_PUBLIC_API_BASE_URL || "", [])
+
+  // QR読み取り結果を受け取り（退避しない）
+  const handleQRScan = (result: string) => {
+    setScannedUserId(result)
+    setIsScanning(false)
+    setError("")
+  }
+
+  // 支払い完了後に完全初期化（退避なしなので state のみ）
+  const resetAfterPayment = (autoRescan = false) => {
+    setPaymentComplete(false)
+    setError("")
+    setAmount("")
+    setScannedUserId("")
+    if (autoRescan) setIsScanning(true)
+  }
+
+  
+  const handlePayment = async () => {
+    if (!scannedUserId || !amount) {
+      setError("ユーザーIDと金額を入力してください")
+      return
+    }
+    if (isNaN(Number(amount)) || Number(amount) <= 0) {
+      setError("正しい金額を入力してください")
+      return
+    }
+    if (!baseUrl) {
+      setError("APIのベースURLが設定されていません（NEXT_PUBLIC_API_BASE_URL）")
+      return
+    }
+
+    setIsProcessing(true)
+    setError("")
+
+    try {
+      const url = joinUrl(baseUrl, "/pos/execute") // ← サーバ実装に合わせ固定
+      setLastTriedUrl(url)
+
+      const payload = { user_id: scannedUserId, amount: Number(amount) }
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      })
+
+      if (!res.ok) {
+        const maybeJson = await res.json().catch(() => ({ detail: `HTTP ${res.status}` }))
+        const message =
+          (maybeJson && (maybeJson.detail || maybeJson.message)) ||
+          `支払い処理に失敗しました (HTTP ${res.status})`
+        throw new Error(message)
+      }
+
+      const data: ExecuteResponse = await res.json()
+      console.log("ExecuteResponse:", data)
+
+      setPaymentComplete(true)
+
+      // 完了アニメ表示後に初期化（次のQR読み取りに備える）
+      setTimeout(() => {
+        resetAfterPayment(/* autoRescan */ false) // trueにすると完了後に自動でスキャン開始
+      }, 3000)
+    } catch (err: any) {
+      console.error("POS payment failed:", err?.message || err, "tried:", lastTriedUrl)
+      // 画面には詳しい赤枠は出さないポリシー
+      setError("支払い処理に失敗しました")
+    } finally {
+      setIsProcessing(false)
+    }
+  }
+
+  // 手動リセット（退避がないので state を空に戻すだけ）
+  const resetForm = () => {
+    setScannedUserId("")
+    setAmount("")
+    setError("")
+    setPaymentComplete(false)
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-purple-300 via-pink-200 to-blue-200 px-4 py-6">
+      <HideGlobalFooter /> {/* ← この1行を追加：このページ表示中だけフッター非表示 */}
+      <div className="max-w-sm mx-auto">
+        <div className="text-center mb-6">
+          <h1 className="text-3xl font-bold text-gray-800 mb-1">たなぼた!</h1>
+          <p className="text-gray-600 text-sm">POSレジシステム</p>
+        </div>
+
+        <div className="bg-white/90 backdrop-blur-sm rounded-3xl p-5 shadow-xl">
+          {/* QR Scanner Modal */}
+          <AnimatePresence>
+            {isScanning && (
+              <motion.div
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+              >
+                <motion.div
+                  initial={{ scale: 0.9, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.9, opacity: 0 }}
+                  className="bg-white rounded-2xl p-6 w-full max-w-sm"
+                >
+                  <div className="flex justify-between items-center mb-4">
+                    <h3 className="text-lg font-bold text-gray-800">QRコードをスキャン</h3>
+                    <button
+                      onClick={() => setIsScanning(false)}
+                      className="p-2 hover:bg-gray-100 rounded-full transition-colors"
+                    >
+                      <X size={20} className="text-gray-600" />
+                    </button>
+                  </div>
+                  <QrScanner onScan={handleQRScan} />
+                </motion.div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* 支払い完了アニメ */}
+          <AnimatePresence>
+            {paymentComplete && (
+              <motion.div
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                exit={{ opacity: 0, scale: 0.8 }}
+                className="fixed inset-0 bg-black/80 z-50 flex items-center justify-center p-4"
+              >
+                <motion.div
+                  initial={{ y: 50 }}
+                  animate={{ y: 0 }}
+                  className="bg-white rounded-3xl p-8 text-center max-w-sm w-full"
+                >
+                  <motion.div
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                    transition={{ delay: 0.2, type: "spring", stiffness: 200 }}
+                    className="w-20 h-20 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-4"
+                  >
+                    <Check size={40} className="text-white" />
+                  </motion.div>
+                  <h3 className="text-2xl font-bold text-gray-800 mb-2">支払い完了！</h3>
+                  <p className="text-gray-600 mb-2">¥{Number(amount).toLocaleString()}</p>
+                  <p className="text-sm text-gray-500">ありがとうございました</p>
+                </motion.div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {/* エラーパネルは出さない（必要ならトースト等へ差し替え可） */}
+
+          <button
+            onClick={() => setIsScanning(true)}
+            disabled={isProcessing}
+            className="w-full bg-gradient-to-r from-purple-500 to-pink-500 text-white font-bold py-4 rounded-2xl mb-5 flex items-center justify-center gap-3 shadow-lg hover:shadow-xl transition-all disabled:opacity-50 text-lg"
+          >
+            <Camera size={24} />
+            QRをスキャン
+          </button>
+
+          {/* 読み取ったユーザーID */}
+          {scannedUserId && (
+            <motion.div
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="bg-green-100 border border-green-300 rounded-2xl p-4 mb-5"
+            >
+              <p className="text-green-700 text-sm text-center">
+                <span className="font-medium">ユーザーID:</span> {scannedUserId}
+              </p>
+            </motion.div>
+          )}
+
+          {/* 金額入力（テキスト¥） */}
+          <div className="mb-5">
+            <label className="block text-gray-700 text-sm font-medium mb-2">金額を入力</label>
+            <div className="relative">
+              <div className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 text-lg font-semibold">
+                ¥
+              </div>
+              <input
+                type="number"
+                value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                placeholder="金額を入力してください"
+                className="w-full pl-12 pr-4 py-4 bg-gray-50 border-0 rounded-2xl text-lg font-medium text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:bg-white transition-all"
+                disabled={isProcessing}
+                inputMode="numeric"
+                min={0}
+              />
+            </div>
+          </div>
+
+          {/* 実行ボタン */}
+          <button
+            onClick={handlePayment}
+            disabled={!scannedUserId || !amount || isProcessing}
+            className="w-full bg-gradient-to-r from-purple-600 to-pink-600 text-white font-bold py-4 rounded-2xl shadow-lg hover:shadow-xl transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 text-lg"
+          >
+            {isProcessing ? (
+              <>
+                <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                処理中...
+              </>
+            ) : (
+              <>
+                <Check size={20} />
+                OK（たなぼた、実行！）
+              </>
+            )}
+          </button>
+
+          {/* 手動リセット */}
+          {(scannedUserId || amount) && !isProcessing && (
+            <button
+              onClick={resetForm}
+              className="w-full mt-4 bg-gray-200 text-gray-700 font-medium py-3 rounded-2xl hover:bg-gray-300 transition-colors"
+            >
+              リセット
+            </button>
+          )}
+        </div>
+
+        <div className="text-center mt-6 text-gray-600 text-xs">
+          <p>© 2025 たなぼた POS System</p>
+        </div>
+      </div>
+    </div>
+  )
+}
+// ...existing code...
+  async function startScan(): Promise<void> {
+    if (!scanSupported) {
+      setError(
+        "このブラウザは QR デコードに未対応です（手入力か画像読み取りをご利用ください）"
+      );
+      return;
+    }
+    setError("");
+    setIsLoading(true);
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: "environment" },
+        audio: false,
+      });
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+      }
+      // BarcodeDetector APIの初期化
+      if ("BarcodeDetector" in window) {
+        const supportedFormats = await (window as any).BarcodeDetector.getSupportedFormats();
+        barcodeDetectorRef.current = new (window as any).BarcodeDetector({
+          formats: supportedFormats,
+        }) as BarcodeDetectorLike;
+      } else {
+        setError("このブラウザは BarcodeDetector API に未対応です");
+      }
+      setIsLoading(false);
+      scanLoop();
+    } catch (err) {
+      console.error("カメラの起動に失敗:", err);
+      setError("カメラの起動に失敗しました。設定を確認してください。");
+      setIsLoading(false);
+    }
+  }

--- a/src/components/qr-scanner.tsx
+++ b/src/components/qr-scanner.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { Camera, AlertCircle, Image as ImageIcon, Upload } from "lucide-react"
+import jsQR from "jsqr"
+
+interface QrScannerProps {
+  onScan: (result: string) => void
+}
+
+export default function QrScanner({ onScan }: QrScannerProps) {
+  const videoRef = useRef<HTMLVideoElement>(null)
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string>("")
+  const [stream, setStream] = useState<MediaStream | null>(null)
+
+  const scanTimerRef = useRef<number | null>(null)
+  const failTimeoutRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    startCamera()
+    return () => {
+      stopScanning()
+      stopCamera()
+      if (failTimeoutRef.current) {
+        clearTimeout(failTimeoutRef.current)
+        failTimeoutRef.current = null
+      }
+    }
+  }, [])
+
+  const startCamera = async () => {
+    try {
+      setIsLoading(true)
+      setError("")
+
+      const mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: { ideal: "environment" }, width: { ideal: 640 }, height: { ideal: 480 } },
+        audio: false,
+      })
+
+      setStream(mediaStream)
+
+      if (videoRef.current) {
+        videoRef.current.srcObject = mediaStream as MediaStream
+        await videoRef.current.play()
+      }
+
+      setIsLoading(false)
+      startScanning()
+    } catch (err) {
+      console.error("Camera access error:", err)
+      setError("カメラにアクセスできません。許可設定を確認するか、画像から読み取ってください。")
+      setIsLoading(false)
+    }
+  }
+
+  const stopCamera = () => {
+    if (stream) {
+      stream.getTracks().forEach((track) => track.stop())
+      setStream(null)
+    }
+  }
+
+  const startScanning = () => {
+    stopScanning()
+    const tick = () => {
+      if (!videoRef.current || !canvasRef.current) return
+      const video = videoRef.current
+      const canvas = canvasRef.current
+      const ctx = canvas.getContext("2d")
+      if (!ctx) return
+
+      if (video.readyState === video.HAVE_ENOUGH_DATA) {
+        const w = video.videoWidth
+        const h = video.videoHeight
+        if (w && h) {
+          canvas.width = w
+          canvas.height = h
+          ctx.drawImage(video, 0, 0, w, h)
+          const imageData = ctx.getImageData(0, 0, w, h)
+          const code = jsQR(imageData.data, imageData.width, imageData.height, { inversionAttempts: "dontInvert" })
+          if (code && code.data) {
+            onScan(code.data)
+            stopScanning()
+            stopCamera()
+            if (failTimeoutRef.current) {
+              clearTimeout(failTimeoutRef.current)
+              failTimeoutRef.current = null
+            }
+            return
+          }
+        }
+      }
+      scanTimerRef.current = window.setTimeout(tick, 200)
+    }
+    tick()
+
+    // 10秒でタイムアウト → エラー表示＋画像読み取り案内
+    failTimeoutRef.current = window.setTimeout(() => {
+      if (scanTimerRef.current) {
+        stopScanning()
+        setError("QRコードを検出できませんでした。明るさやピントを調整するか、画像から読み取ってください。")
+      }
+    }, 10000)
+  }
+
+  const stopScanning = () => {
+    if (scanTimerRef.current) {
+      clearTimeout(scanTimerRef.current)
+      scanTimerRef.current = null
+    }
+  }
+
+  // 画像ファイル fallback
+  const triggerFileSelect = () => fileInputRef.current?.click()
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+    decodeFromFile(file)
+    e.currentTarget.value = ""
+  }
+
+  const decodeFromFile = (file: File) => {
+    setError("")
+    stopScanning()
+    stopCamera()
+
+    const img = new Image()
+    const objectUrl = URL.createObjectURL(file)
+    img.onload = () => {
+      try {
+        const canvas = document.createElement("canvas")
+        canvas.width = img.width
+        canvas.height = img.height
+        const ctx = canvas.getContext("2d")
+        if (!ctx) {
+          setError("画像の読み込みに失敗しました。別の画像でお試しください。")
+          return
+        }
+        ctx.drawImage(img, 0, 0)
+        const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height)
+        const code = jsQR(imageData.data, imageData.width, imageData.height, { inversionAttempts: "dontInvert" })
+        if (code?.data) {
+          onScan(code.data)
+        } else {
+          setError("画像からQRを検出できませんでした。別の角度・解像度でお試しください。")
+        }
+      } finally {
+        URL.revokeObjectURL(objectUrl)
+      }
+    }
+    img.onerror = () => {
+      URL.revokeObjectURL(objectUrl)
+      setError("画像の読み込みに失敗しました。")
+    }
+    img.src = objectUrl
+  }
+
+  if (error && !isLoading) {
+    return (
+      <div className="text-center py-6">
+        <AlertCircle size={48} className="text-red-500 mx-auto mb-4" />
+        <p className="text-red-600 text-sm mb-4">{error}</p>
+
+        <div className="flex items-center justify-center gap-3">
+          <button
+            onClick={startCamera}
+            className="px-4 py-2 bg-purple-500 text-white rounded-lg hover:bg-purple-600 transition-colors"
+          >
+            再試行（カメラ）
+          </button>
+          <button
+            onClick={triggerFileSelect}
+            className="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300 transition-colors flex items-center gap-2"
+          >
+            <Upload size={18} />
+            画像から読み取る
+          </button>
+        </div>
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative">
+      {isLoading && (
+        <div className="absolute inset-0 bg-gray-100 rounded-xl flex items-center justify-center z-10">
+          <div className="text-center">
+            <Camera size={48} className="text-gray-400 mx-auto mb-4 animate-pulse" />
+            <p className="text-gray-600 text-sm">カメラを起動中...</p>
+          </div>
+        </div>
+      )}
+
+      <div className="relative bg-black rounded-xl overflow-hidden">
+        <video ref={videoRef} className="w-full h-64 object-cover" playsInline muted />
+
+        {/* QRガイド枠 */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-48 h-48 border-2 border-white rounded-lg relative">
+            <div className="absolute top-0 left-0 w-6 h-6 border-t-4 border-l-4 border-purple-500 rounded-tl-lg"></div>
+            <div className="absolute top-0 right-0 w-6 h-6 border-t-4 border-r-4 border-purple-500 rounded-tr-lg"></div>
+            <div className="absolute bottom-0 left-0 w-6 h-6 border-b-4 border-l-4 border-purple-500 rounded-bl-lg"></div>
+            <div className="absolute bottom-0 right-0 w-6 h-6 border-b-4 border-r-4 border-purple-500 rounded-br-lg"></div>
+          </div>
+        </div>
+
+        {/* スキャンライン */}
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="w-48 h-1 bg-purple-500 opacity-75 animate-pulse"></div>
+        </div>
+      </div>
+
+      <canvas ref={canvasRef} className="hidden" />
+
+      {/* 画像から読み取り（常時表示） */}
+      <div className="mt-4 flex flex-col items-center">
+        <button
+          onClick={triggerFileSelect}
+          className="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors flex items-center gap-2 text-sm"
+        >
+          <ImageIcon size={16} />
+          画像から読み取る
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          onChange={handleFileChange}
+          className="hidden"
+        />
+        <p className="text-center text-sm text-gray-600 mt-3">QRコードをカメラに向けてください</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
# POS: QRスキャン＋決済POST実装/ 自動初期化 / フッター非表示

## 概要

* 既存デザインを変更せず、**QRスキャンで取得した `user_id` と入力金額を `/pos/execute` にPOST**する機能を実装。
* ページ起動時は常に初期状態。**POST成功後も初期化**して次のQRを読み取れるようにした。
* **カメラが使えない端末向けのフォールバック**：画像ファイルからのQR読取を追加。
* **このページ表示中のみ、フッターツールバー（下部ナビ）を非表示**。

## 変更点（主な実装）

* `page.tsx`

  * `QrScanner` を **動的import（`next/dynamic`）＆SSR無効**で安全に読み込み（named/defaultどちらでも対応）。
  * **POST先を `/pos/execute` に固定**（`NEXT_PUBLIC_API_BASE_URL` と結合）。
  * **成功時アニメ後に state 初期化**（`user_id/amount/error` をクリア）。
  * 画面の赤エラーパネルは撤去し、**console のみ**にエラー詳細を出力。
  * **フッター非表示**用の `HideGlobalFooter` を追加（このページ遷移中のみDOMを非表示にし、離脱で復元）。
  * 金額アイコンは **テキスト `¥`** を使用（未定義アイコンによるクラッシュ回避）。
* `components/qr-scanner.tsx`

  * **`jsQR` によるQR復号**を実装（動画フレーム/画像ファイル双方に対応）。
  * カメラ取得失敗/10秒無検出時はメッセージ表示＋\*\*「画像から読み取る」\*\*ボタンを提示。
  * **default export** に統一（importの取り違え防止）。
* 依存関係

  * `jsqr` を追加。

## 追加・変更ファイル

* `src/app/tanabota_pos/page.tsx`（全面改修）
* `src/components/qr-scanner.tsx`（default export化／画像フォールバック追加）
* `package.json`（`jsqr` 追加）

## 環境変数

* 必須：`NEXT_PUBLIC_API_BASE_URL`

  * 例）`https://aps-irodori-sub-01-gxbyb0d3bafadgdz.japaneast-01.azurewebsites.net`
* **POST先は固定**：`<BASE_URL>/pos/execute`

## セットアップ

```bash
npm i jsqr
# or
yarn add jsqr
```

## 動作確認手順

1. アプリ起動 → `たなぼた POS` ページへ遷移（フッターが非表示になっていること）。
2. 「QRをスキャン」→ 端末のカメラ許可 → QRをかざす

   * カメラ不可端末/失敗時：**「画像から読み取る」** を選び、QR画像をアップロード。
3. ユーザーIDが表示されたら金額を入力し「OK（たなぼた、実行！）」をクリック。
4. APIに `POST /pos/execute`（payload: `{ user_id, amount }`）→ 成功アニメ表示。
5. **約3秒後、自動で初期化**（`user_id/amount`がクリアされ、次の読み取りができる状態）。

### 失敗時の挙動

* 画面には詳細エラーを出さず、**console** にのみ詳細（HTTPステータス等）を出力。
* 例）`console.error("POS payment failed:", err, "tried:", url)`

## 影響範囲 / 互換性

* 対象ページのみ。**全体レイアウトやデザインは不変**。
* フッターは**このページ表示中のみ**非表示にし、離脱で復元。
* `localStorage` 不使用化により、**ユーザーIDの保持は行わない**（毎回スキャン前提）。

## セキュリティ・権限

* カメラアクセスは `getUserMedia`（安全なオリジンのみ）。Azure本番はHTTPSのためOK。
* **個人情報の永続保存なし**（退避廃止）。
* CORSはサーバ側設定に依存（今回のPRでは変更なし）。

## パフォーマンス

* スキャン間隔：200ms。10秒で自動タイムアウト。
* 動的importでスキャナを必要時のみロード。SSRはオフ（ブラウザAPI前提）。

## 既知の課題 / フォローアップ（任意）

* PWAアイコン404（`/icon-144x144.png`）は**別PR**で `public/icons` と `manifest` を整備予定。
* 失敗トースト表示などのUX改善は別タスクで検討可。

## レビューポイント

* [ ] `POST /pos/execute` が正しく叩ける（`NEXT_PUBLIC_API_BASE_URL` 設定済み）
* [ ] 成功後、**stateが初期化**され次のスキャンに移れる
* [ ] カメラ不可端末で**画像からの読み取り**が機能する
* [ ] フッター（下部ツールバー）が**このページでのみ非表示**
* [ ] 画面に赤いエラーパネルが出ない（詳細はconsole出力）

---

### PRタイトル案

`feat(pos): QRスキャン→/pos/execute決済POST・自動初期化・フッター非表示・jsQR導入`
